### PR TITLE
 PiT post-modulation to mitigate training loss spikes (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+c2i/train_logs/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ PixelDiT is a single-stage, end-to-end pixel-space diffusion transformer that el
 
 ## 🔥 News 
 
-- **[2025/11]** Paper, training & inference code, and pre-trained models are released.
+- **[2026/06]** Added a **post-modulation** option for the PiT (pixel-level) blocks that mitigates the training loss spikes ([#6](https://github.com/NVlabs/PixelDiT/issues/6)). See [c2i/README.md](c2i/README.md#training-stability-post-modulation-for-pit-blocks).
+- **[2026/06]** PixelDiT is selected as a CVPR 2026 Best Paper Finalist.
+- **[2026/04]** Training & inference code, and pre-trained models are released.
+- **[2026/02]** PixelDiT is accepted to CVPR 2026 Oral. 
+- **[2025/11]** [arxiv](https://arxiv.org/abs/2511.20645) is released.
 
 ## Performance
 

--- a/c2i/README.md
+++ b/c2i/README.md
@@ -55,6 +55,20 @@ Auto-resume is enabled by default in the config (`auto_resume: true`). If a prev
 
 Checkpoints are auto-downloaded from HuggingFace if the file does not exist locally. Just pass the filename to `--ckpt_path`.
 
+### Training Stability: Post-Modulation for PiT Blocks
+
+If you observe sudden loss / gradient-norm spikes during training (see [#6](https://github.com/NVlabs/PixelDiT/issues/6)), enable **post-modulation adaLN** for the pixel-level (PiT) blocks. Instead of the default 6-way pre-modulation (shift/scale/gate applied to the attention & MLP inputs), each PiT block applies a 4-way scale/shift to the attention & MLP **outputs** (no gate), which mitigates the spikes. Only the PiT blocks are affected; the patch-level blocks are unchanged.
+
+This is controlled by `pit_adaln_post_modulation: true` in the denoiser config and is fully backward compatible (default `false`). Ready-to-use configs are provided:
+
+```bash
+cd c2i/
+# ImageNet 256×256
+bash train_c2i.sh --num-gpus 8 --config configs/pix256_xl_pit_post_modulation.yaml
+# ImageNet 512×512
+bash train_c2i.sh --num-gpus 8 --config configs/pix512_xl_pit_post_modulation.yaml
+```
+
 ## Evaluation
 
 Evaluation generates 50K images via `main.py predict`, then computes FID using the [ADM evaluation suite](https://github.com/openai/guided-diffusion/tree/main/evaluations).

--- a/c2i/configs/pix256_xl_pit_post_modulation.yaml
+++ b/c2i/configs/pix256_xl_pit_post_modulation.yaml
@@ -1,0 +1,119 @@
+seed_everything: true
+per_run_seed: true
+tags:
+  exp: &exp pixeldit_c2i_bs256_pit_post_modulation
+torch_hub_dir: null
+huggingface_cache_dir: null
+auto_resume: true
+trainer:
+  default_root_dir: ./train_logs/
+  accelerator: gpu
+  strategy: ddp
+  devices: 8
+  num_nodes: 1
+  precision: bf16-mixed
+  gradient_clip_val: 1.0
+  gradient_clip_algorithm: norm
+  logger:
+      class_path: lightning.pytorch.loggers.WandbLogger
+      init_args:
+        project: pix_dit_c2i
+        name: *exp
+  num_sanity_val_steps: 0
+  max_steps: 1600000
+  val_check_interval: 100000
+  check_val_every_n_epoch: null
+  log_every_n_steps: 50
+  deterministic: null
+  inference_mode: true
+  use_distributed_sampler: false
+  callbacks:
+    - class_path: src.utils.CheckpointHook
+      init_args:
+        every_n_train_steps: 10000
+        save_top_k: -1
+        save_last: true
+    - class_path: src.utils.SaveImagesHook
+      init_args:
+         save_dir: val_256_xl
+         save_compressed: true
+model:
+  enable_profiling: true
+  profiling_print_freq: 1000
+  profiling_warmup_steps: 100
+  override_lr_on_resume: null
+  override_ema_decay_on_resume: null
+  num_classes: 1000
+  denoiser:
+    class_path: pixdit_core.pixeldit_c2i.PixDiT
+    init_args:
+        in_channels: 3
+        patch_size: 16
+        num_groups: 16
+        hidden_size: &hidden_dim 1152
+        patch_depth: 26
+        pixel_depth: 4
+        num_classes: 1000
+        pixel_hidden_size: 16
+        # PiT post-modulation adaLN: enable for mitigating loss spike
+        pit_adaln_post_modulation: true
+  diffusion_trainer:
+    class_path: src.diffusion.REPATrainer
+    init_args:
+      lognorm_t: true
+      timeshift: 1.0
+      encoder:
+        class_path: src.diffusion.DINOv2
+      align_layer: 8
+      proj_denoiser_dim: *hidden_dim
+      proj_hidden_dim: *hidden_dim
+      proj_encoder_dim: 768
+      scheduler: &scheduler src.diffusion.LinearScheduler
+  diffusion_sampler:
+    class_path: src.diffusion.FlowDPMSolverSampler
+    init_args:
+      num_steps: 100
+      guidance: 3.25
+      timeshift: 1.0
+      guidance_interval_min: 0.1
+      guidance_interval_max: 1.0
+      scheduler: *scheduler
+      w_scheduler: src.diffusion.LinearScheduler
+      guidance_fn: src.diffusion.simple_guidance_fn
+      step_fn: src.diffusion.ode_step_fn
+  ema_tracker:
+    class_path: src.utils.SimpleEMA
+    init_args:
+      decay: 0.9999
+  optimizer:
+    class_path: torch.optim.AdamW
+    init_args:
+      lr: 1e-4
+      weight_decay: 0.0
+data:
+  train_dataset:
+    class_path: src.data.CustomINH5Dataset
+    init_args:
+      data_dir: ./imagenet256_data
+  eval_dataset:
+    class_path: src.data.ClassLabelRandomNDataset
+    init_args:
+      num_classes: 1000
+      max_num_instances: 50000
+      latent_shape:
+        - 3
+        - 256
+        - 256
+  pred_dataset:
+    class_path: src.data.ClassLabelRandomNDataset
+    init_args:
+      num_classes: 1000
+      max_num_instances: 50000
+      latent_shape:
+        - 3
+        - 256
+        - 256
+  train_batch_size: 32
+  train_num_workers: 4
+  pred_batch_size: 32
+  pred_num_workers: 1

--- a/c2i/configs/pix512_xl_pit_post_modulation.yaml
+++ b/c2i/configs/pix512_xl_pit_post_modulation.yaml
@@ -1,0 +1,119 @@
+seed_everything: true
+per_run_seed: true
+tags:
+  exp: &exp pixeldit_c2i_bs256_shift3_res512_pit_post_modulation
+torch_hub_dir: null
+huggingface_cache_dir: null
+auto_resume: true
+trainer:
+  default_root_dir: ./train_logs/
+  accelerator: gpu
+  strategy: ddp
+  devices: 8
+  num_nodes: 1
+  precision: bf16-mixed
+  gradient_clip_val: 0.5
+  gradient_clip_algorithm: norm
+  logger:
+      class_path: lightning.pytorch.loggers.WandbLogger
+      init_args:
+        project: pix_dit_c2i
+        name: *exp
+  num_sanity_val_steps: 0
+  max_steps: 4000000
+  val_check_interval: 1000000
+  check_val_every_n_epoch: null
+  log_every_n_steps: 50
+  deterministic: null
+  inference_mode: true
+  use_distributed_sampler: false
+  callbacks:
+    - class_path: src.utils.CheckpointHook
+      init_args:
+        every_n_train_steps: 10000
+        save_top_k: -1
+        save_last: true
+    - class_path: src.utils.SaveImagesHook
+      init_args:
+         save_dir: val_512_xl
+         save_compressed: true
+model:
+  enable_profiling: true
+  profiling_print_freq: 1000
+  profiling_warmup_steps: 100
+  override_lr_on_resume: null
+  override_ema_decay_on_resume: null
+  num_classes: 1000
+  denoiser:
+    class_path: pixdit_core.pixeldit_c2i.PixDiT
+    init_args:
+        in_channels: 3
+        patch_size: 16
+        num_groups: 16
+        hidden_size: &hidden_dim 1152
+        patch_depth: 26
+        pixel_depth: 4
+        num_classes: 1000
+        pixel_hidden_size: 16
+        # PiT post-modulation adaLN: enable for mitigating loss spike
+        pit_adaln_post_modulation: true
+  diffusion_trainer:
+    class_path: src.diffusion.REPATrainer
+    init_args:
+      lognorm_t: true
+      timeshift: 3.0
+      encoder:
+        class_path: src.diffusion.DINOv2
+      align_layer: 8
+      proj_denoiser_dim: *hidden_dim
+      proj_hidden_dim: *hidden_dim
+      proj_encoder_dim: 768
+      scheduler: &scheduler src.diffusion.LinearScheduler
+  diffusion_sampler:
+    class_path: src.diffusion.FlowDPMSolverSampler
+    init_args:
+      num_steps: 100
+      guidance: 3.75
+      timeshift: 3.0
+      guidance_interval_min: 0.1
+      guidance_interval_max: 1.0
+      scheduler: *scheduler
+      w_scheduler: src.diffusion.LinearScheduler
+      guidance_fn: src.diffusion.simple_guidance_fn
+      step_fn: src.diffusion.ode_step_fn
+  ema_tracker:
+    class_path: src.utils.SimpleEMA
+    init_args:
+      decay: 0.9999
+  optimizer:
+    class_path: torch.optim.AdamW
+    init_args:
+      lr: 1e-4
+      weight_decay: 0.0
+data:
+  train_dataset:
+    class_path: src.data.CustomINH5Dataset
+    init_args:
+      data_dir: ./imagenet512_data
+  eval_dataset:
+    class_path: src.data.ClassLabelRandomNDataset
+    init_args:
+      num_classes: 1000
+      max_num_instances: 50000
+      latent_shape:
+        - 3
+        - 512
+        - 512
+  pred_dataset:
+    class_path: src.data.ClassLabelRandomNDataset
+    init_args:
+      num_classes: 1000
+      max_num_instances: 50000
+      latent_shape:
+        - 3
+        - 512
+        - 512
+  train_batch_size: 8
+  train_num_workers: 4
+  pred_batch_size: 16
+  pred_num_workers: 1

--- a/c2i/src/utils.py
+++ b/c2i/src/utils.py
@@ -104,10 +104,11 @@ class CheckpointHook(ModelCheckpoint):
 
 
 class SaveImagesHook(Callback):
-    def __init__(self, save_dir: str = "val", save_compressed: bool = False):
+    def __init__(self, save_dir: str = "val", save_compressed: bool = False, predict_tag: str = "predict"):
         super().__init__()
         self.save_dir = save_dir
         self.save_compressed = save_compressed
+        self.predict_tag = predict_tag
         self.samples = []
         self.target_dir = None
         self.executor_pool = None
@@ -185,7 +186,7 @@ class SaveImagesHook(Callback):
         self.save_end()
 
     def on_predict_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        target_dir = os.path.join(trainer.default_root_dir, self.save_dir, "predict")
+        target_dir = os.path.join(trainer.default_root_dir, self.save_dir, self.predict_tag)
         self.save_start(target_dir)
 
     def on_predict_batch_end(

--- a/pixdit_core/pixeldit_c2i.py
+++ b/pixdit_core/pixeldit_c2i.py
@@ -122,6 +122,7 @@ class PiTBlock(nn.Module):
         attn_hidden_size: Optional[int] = None,
         attn_num_heads: Optional[int] = None,
         rope_fn=None,
+        adaln_post_modulation: bool = False,
     ):
         super().__init__()
         self.pixel_dim = int(pixel_hidden_size)
@@ -139,7 +140,9 @@ class PiTBlock(nn.Module):
         self.attn = RotaryAttention(self.attn_dim, num_heads=self.num_heads, qkv_bias=False)
         self.norm2 = RMSNorm(self.pixel_dim, eps=1e-6)
         self.mlp = MLP(self.pixel_dim, mlp_ratio=mlp_ratio, drop=0.0)
-        self.adaLN_modulation = nn.Sequential(nn.Linear(self.context_dim, 6 * self.pixel_dim * p2, bias=True))
+        self.adaln_post_modulation = bool(adaln_post_modulation)
+        n_mod = 4 if self.adaln_post_modulation else 6
+        self.adaLN_modulation = nn.Sequential(nn.Linear(self.context_dim, n_mod * self.pixel_dim * p2, bias=True))
         self._pos_cache = dict()
         self._rope_fn = rope_fn if rope_fn is not None else precompute_freqs_cis_2d
 
@@ -159,19 +162,28 @@ class PiTBlock(nn.Module):
         Hs, Ws = image_height // patch_size, image_width // patch_size
         L = Hs * Ws
         B = BL // L
-        cond_params = self.adaLN_modulation(s_cond)
-        cond_params = cond_params.view(BL, P2, 6 * self.pixel_dim)
-        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = torch.chunk(cond_params, 6, dim=-1)
-        x_norm = apply_adaln(self.norm1(x), shift_msa, scale_msa)
+        n_mod = 4 if self.adaln_post_modulation else 6
+        cond_params = self.adaLN_modulation(s_cond).view(BL, P2, n_mod * self.pixel_dim)
+        if self.adaln_post_modulation:
+            scale1, shift1, scale2, shift2 = torch.chunk(cond_params, 4, dim=-1)
+            x_norm = self.norm1(x)
+        else:
+            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = torch.chunk(cond_params, 6, dim=-1)
+            x_norm = apply_adaln(self.norm1(x), shift_msa, scale_msa)
         x_flat = x_norm.view(BL, P2 * self.pixel_dim)
         x_comp = self.compress_to_attn(x_flat).view(B, L, self.attn_dim)
         pos_comp = self._fetch_pos(Hs, Ws, x.device)
         attn_out = self.attn(x_comp, pos_comp, mask)
         attn_flat = self.expand_from_attn(attn_out.view(B * L, self.attn_dim))
         attn_exp = attn_flat.view(BL, P2, self.pixel_dim)
-        x = x + gate_msa * attn_exp
-        mlp_out = self.mlp(apply_adaln(self.norm2(x), shift_mlp, scale_mlp))
-        x = x + gate_mlp * mlp_out
+        if self.adaln_post_modulation:
+            x = x + attn_exp * (1 + scale1) + shift1
+            mlp_out = self.mlp(self.norm2(x))
+            x = x + mlp_out * (1 + scale2) + shift2
+        else:
+            x = x + gate_msa * attn_exp
+            mlp_out = self.mlp(apply_adaln(self.norm2(x), shift_mlp, scale_mlp))
+            x = x + gate_mlp * mlp_out
         return x
 
 
@@ -187,6 +199,7 @@ class PixDiT(nn.Module):
         patch_size=2,
         num_classes=1000,
         use_pixel_abs_pos=True,
+        pit_adaln_post_modulation=False,
     ):
         super().__init__()
         self.in_channels = int(in_channels)
@@ -199,6 +212,7 @@ class PixDiT(nn.Module):
         self.pixel_hidden_size = int(pixel_hidden_size)
         self.num_classes = int(num_classes)
         self.use_pixel_abs_pos = bool(use_pixel_abs_pos)
+        self.pit_adaln_post_modulation = bool(pit_adaln_post_modulation)
         if self.pixel_depth <= 0:
             raise ValueError("PixDiT expects pixel_depth > 0 to preserve the dual-level pipeline")
 
@@ -219,6 +233,7 @@ class PixDiT(nn.Module):
                     patch_size=self.patch_size,
                     num_heads=self.num_groups,
                     mlp_ratio=4.0,
+                    adaln_post_modulation=self.pit_adaln_post_modulation,
                 )
                 for _ in range(self.pixel_depth)
             ]

--- a/pixdit_core/pixeldit_t2i.py
+++ b/pixdit_core/pixeldit_t2i.py
@@ -151,6 +151,7 @@ class PixDiT_T2I(nn.Module):
         text_rope_theta: float = 10000.0,
         repa_encoder_index: int = -1,
         use_pixel_abs_pos: bool = True,
+        pit_adaln_post_modulation: bool = False,
     ):
         super().__init__()
         self.in_channels = int(in_channels)
@@ -168,6 +169,7 @@ class PixDiT_T2I(nn.Module):
         self.text_rope_theta = float(text_rope_theta)
         self.repa_encoder_index = int(repa_encoder_index)
         self.use_pixel_abs_pos = bool(use_pixel_abs_pos)
+        self.pit_adaln_post_modulation = bool(pit_adaln_post_modulation)
         if self.pixel_depth <= 0:
             raise ValueError("PixDiT_T2I expects pixel_depth > 0 to retain the pixel pathway")
 
@@ -205,6 +207,7 @@ class PixDiT_T2I(nn.Module):
                     attn_hidden_size=self.pixel_attn_hidden_size,
                     attn_num_heads=self.pixel_num_groups,
                     rope_fn=precompute_freqs_cis_2d,
+                    adaln_post_modulation=self.pit_adaln_post_modulation,
                 )
                 for _ in range(self.pixel_depth)
             ]

--- a/t2i/configs/PixelDiT_512px_pixel_diffusion_stage1_pit_post_modulation.yaml
+++ b/t2i/configs/PixelDiT_512px_pixel_diffusion_stage1_pit_post_modulation.yaml
@@ -1,0 +1,118 @@
+# Stage 1 + PiT post-modulation: Train from Scratch; Fixed 512px; No multiscale; REPA loss weight 0.5
+data:
+  data_dir: [data/data_public/dir1]
+  image_size: 512
+  caption_proportion:
+    prompt: 1
+  external_caption_suffixes: ['', _InternVL2-26B, _VILA1-5-13B]
+  external_clipscore_suffixes:
+    - _InternVL2-26B_clip_score
+    - _VILA1-5-13B_clip_score
+    - _prompt_clip_score
+  clip_thr_temperature: 0.1
+  clip_thr: 25.0
+  load_text_feat: false
+  transform: default_train
+  type: PixelDataset  # Pixel-space dataset
+  sort_dataset: false
+
+# model config
+model:
+  model: PixDiTTrainer  # PixelDiT wrapper
+  image_size: 512
+  mixed_precision: "bf16"  # float32 to be safe initially
+  fp32_attention: true
+  load_from:
+  resume_from:
+  aspect_ratio_type: ASPECT_RATIO_512
+  multi_scale: false  # fixed 512
+  class_dropout_prob: 0.1
+  # Backend hyperparameters for PixelDiT
+  extra:
+    patch_size: 16
+    num_groups: 24
+    hidden_size: 1536
+    pixel_hidden_size: 16
+    pixel_attn_hidden_size: 1152
+    pixel_num_groups: 16
+    patch_depth: 14
+    pixel_depth: 2
+    num_text_blocks: 4
+    txt_embed_dim: 2304
+    txt_max_length: 300
+    use_text_rope: true
+    text_rope_theta: 10000.0
+    repa_encoder_index: 6
+    # PiT post-modulation adaLN: enable for mitigating loss spike
+    pit_adaln_post_modulation: true
+
+# text encoder
+text_encoder:
+  text_encoder_name: gemma-2-2b-it
+  y_norm: true
+  y_norm_scale_factor: 0.01
+  model_max_length: 300
+  # CHI
+  chi_prompt:
+    - 'Given a user prompt, generate an "Enhanced prompt" that provides detailed visual descriptions suitable for image generation. Evaluate the level of detail in the user prompt:'
+    - '- If the prompt is simple, focus on adding specifics about colors, shapes, sizes, textures, and spatial relationships to create vivid and concrete scenes.'
+    - '- If the prompt is already detailed, refine and enhance the existing details slightly without overcomplicating.'
+    - 'Here are examples of how to transform or refine prompts:'
+    - '- User Prompt: A cat sleeping -> Enhanced: A small, fluffy white cat curled up in a round shape, sleeping peacefully on a warm sunny windowsill, surrounded by pots of blooming red flowers.'
+    - '- User Prompt: A busy city street -> Enhanced: A bustling city street scene at dusk, featuring glowing street lamps, a diverse crowd of people in colorful clothing, and a double-decker bus passing by towering glass skyscrapers.'
+    - 'Please generate only the enhanced description for the prompt below and avoid including any additional commentary or evaluations:'
+    - 'User Prompt: '
+
+scheduler:
+  predict_flow_v: true
+  noise_schedule: linear_flow
+  pred_sigma: false
+  learn_sigma: false
+  flow_shift: 3.0
+  weighting_scheme: logit_normal
+  logit_mean: 0.0
+  logit_std: 1.0
+  vis_sampler: flow_dpm-solver
+
+# training setting
+train:
+  num_workers: 10
+  seed: 1
+  train_batch_size: 8
+  num_epochs: 100
+  gradient_accumulation_steps: 1
+  grad_checkpointing: true
+  gradient_clip: 0.2
+  repa_loss_weight: 0.5
+  optimizer:
+    betas:
+      - 0.9
+      - 0.999
+      - 0.9999
+    eps:
+      - 1.0e-30
+      - 1.0e-16
+    lr: 0.0001
+    type: CAMEWrapper
+    weight_decay: 0.0
+  lr_schedule: constant
+  lr_schedule_args:
+    num_warmup_steps: 2000
+  local_save_vis: true
+  visualize: true
+  validation_prompts:
+    - dog
+    - portrait photo of a girl, photograph, highly detailed face, depth of field
+    - Self-portrait oil painting, a beautiful cyborg with golden hair, 8k
+    - Astronaut in a jungle, cold color palette, muted colors, detailed, 8k
+    - A photo of beautiful mountain with realistic sunset and blue lake, highly detailed, masterpiece
+    - A vibrant modern city street at night, featuring a giant LED billboard glowing with the words “Love PixelDiT.”
+    - A cute artist cat painting the phrase “PixelDiT is awesome” on a bright canvas.
+  eval_sampling_steps: 500
+  log_interval: 20
+  save_model_epochs: 5
+  save_model_steps: 500
+  work_dir: output/pixeldit_pixel_512_pit_post_modulation
+  online_metric: false
+  eval_metric_step: 2000
+  online_metric_dir: metric_helper

--- a/t2i/diffusion/model/trainer.py
+++ b/t2i/diffusion/model/trainer.py
@@ -64,6 +64,7 @@ class PixDiTTrainer(nn.Module):
         text_rope_theta = float(extra.get("text_rope_theta", 10000.0))
         repa_encoder_index = int(extra.get("repa_encoder_index", -1))
         use_pixel_abs_pos = bool(extra.get("use_pixel_abs_pos", True))
+        pit_adaln_post_modulation = bool(extra.get("pit_adaln_post_modulation", False))
 
         if PixDiT_T2I is None:
             raise ImportError("Failed to import PixDiT_T2I from pixdit_core.pixeldit_t2i. Check repo layout and PYTHONPATH.")
@@ -84,6 +85,7 @@ class PixDiTTrainer(nn.Module):
             text_rope_theta=text_rope_theta,
             repa_encoder_index=repa_encoder_index,
             use_pixel_abs_pos=use_pixel_abs_pos,
+            pit_adaln_post_modulation=pit_adaln_post_modulation,
         )
 
         self.image_size = int(image_size)


### PR DESCRIPTION
## What
Adds an opt-in `pit_adaln_post_modulation` flag to the PiT (pixel-level) blocks.
Instead of the default 6-way pre-modulation (shift/scale/gate on the attention &
MLP inputs), each PiT block applies a 4-way scale/shift to the attention & MLP
**outputs** (no gate). **This mitigates the loss / gradient-norm spikes** reported in #6.

- Backward compatible: default `false`; existing configs/checkpoints unchanged.
- Shared by c2i and t2i (same `PiTBlock`).

## Included
- Core: `pixdit_core/pixeldit_c2i.py`, `pixdit_core/pixeldit_t2i.py`, `t2i/diffusion/model/trainer.py`
- `c2i/src/utils.py`: configurable `SaveImagesHook.predict_tag`
- Configs: `pix256_xl_pit_post_modulation.yaml`, `pix512_xl_pit_post_modulation.yaml`, `PixelDiT_512px_pixel_diffusion_stage1_pit_post_modulation.yaml`
- Docs: `README.md` (News) + `c2i/README.md` (Training Stability section)

## Notes
- A checkpoint trained with this flag has a different PiT adaLN shape, so it must be
  evaluated with the matching `*_pit_post_modulation.yaml` config.
- The c2i path is verified (strict ckpt load + forward + 50K predict). The t2i wiring is
  architecturally consistent and unit-tested, but not yet validated at training scale.

<img width="660" height="534" alt="image" src="https://github.com/user-attachments/assets/a77ae033-eb24-4b81-bea8-f34ad8eb2c52" />
<img width="668" height="532" alt="image" src="https://github.com/user-attachments/assets/6aacdd0a-a49f-4fc8-93d9-019c7be4034a" />

WandB logs are downloadable here: [gradnorm](https://drive.google.com/file/d/1MGv1UhJKMxVWz9yF2qvta9pjYRp-OeNT/view?usp=sharing), [loss](https://drive.google.com/file/d/1ihQzE94o19hFybE6SUNf1x_kqS3tgj0S/view?usp=sharing)

Closes #6